### PR TITLE
test_examples: add -run argument

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -70,7 +70,8 @@ def chdir_back_to_root(mocker):
 
 
 @pytest.mark.parametrize("script", example_scripts)
-def test_example(script, tmpdir):
+@pytest.mark.parametrize("additional_args", [['-run']])
+def test_example(script, tmpdir, additional_args):
     """
     Run the examples/MDF
     """
@@ -96,4 +97,7 @@ def test_example(script, tmpdir):
         os.chdir("%s/translation" % tmpdir)
 
     print(f"Running script {full_script_path} in working dir {os.getcwd()}")
+    orig_argv = sys.argv
+    sys.argv = [os.path.basename(full_script_path)] + additional_args
     runpy.run_path(os.path.basename(full_script_path), run_name="__main__")
+    sys.argv = orig_argv


### PR DESCRIPTION
This is dependent on resolution of #141, which references the test suite failure of this PR currently. If the current case (no arguments) should be tested in addition to `-run`, it can be added to the parametrization of `additional_args` on L73