### PR TITLE
mdf: Function: enable args with value

### DIFF
--- a/src/modeci_mdf/execution_engine.py
+++ b/src/modeci_mdf/execution_engine.py
@@ -324,23 +324,21 @@ class EvaluableFunction:
                 "    Evaluating %s with %s, i.e. [%s]"
                 % (self.function, _params_info(func_params), expr)
             )
-        if self.function.function:
-            for f in mdf_functions:
-                if f == self.function.function:
-                    for arg in self.function.args.keys():
-                        func_params[arg] = evaluate_expr(
-                            self.function.args[arg],
-                            func_params,
-                            verbose=False,
-                            array_format=array_format,
+
+        if self.function.args is not None:
+            for arg in self.function.args:
+                func_params[arg] = evaluate_expr(
+                    self.function.args[arg],
+                    func_params,
+                    verbose=False,
+                    array_format=array_format,
+                )
+                if self.verbose:
+                    print(
+                        "      Arg: {} became: {}".format(
+                            arg, _val_info(func_params[arg])
                         )
-                        if self.verbose:
-                            print(
-                                "      Arg: {} became: {}".format(
-                                    arg, _val_info(func_params[arg])
-                                )
-                            )
-                    break
+                    )
 
         # If this is an ONNX operation, evaluate it without modelspec.
 

--- a/src/modeci_mdf/mdf.py
+++ b/src/modeci_mdf/mdf.py
@@ -91,6 +91,11 @@ class Function(MdfBase):
         else:
             id = o["id"]
 
+        try:
+            args = o["args"]
+        except KeyError:
+            args = {}
+
         if "function" in o.keys() and isinstance(o["function"], dict):
             func_name = list(o["function"].keys())[0]
             args = o["function"][func_name]
@@ -98,7 +103,7 @@ class Function(MdfBase):
         elif "function" in o.keys() and isinstance(o["function"], str):
             return cls(id=id, function=o["function"], args=o["args"])
         elif "value" in o.keys():
-            return cls(id=id, value=o["value"])
+            return cls(id=id, value=o["value"], args=args)
         else:
             raise ValueError(f"Could not parse function specification: {o}")
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,67 @@
+import pytest
+
+import modeci_mdf.mdf as mdf
+from modeci_mdf.execution_engine import EvaluableGraph
+
+
+def create_model(nodes=None, edges=None):
+    if nodes is None:
+        nodes = []
+
+    if edges is None:
+        edges = []
+
+    return mdf.Model(
+        id="M",
+        graphs=[
+            mdf.Graph(
+                id="G",
+                nodes=nodes,
+                edges=edges,
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "function, value, result",
+    [
+        ("linear", None, 6),
+        # execution is in favor of function not value
+        ("linear", "2 * slope * variable0 + intercept", 6),
+        (None, "2 * slope * variable0 + intercept", 8),
+        (None, "slope + intercept", 6),
+    ],
+)
+@pytest.mark.parametrize(
+    "args",
+    [
+        {"slope": 2, "intercept": 4, "variable0": 1},
+        {"slope": 2, "intercept": 4, "variable0": "input"},
+        {"slope": 2, "intercept": 4, "variable0": "input"},
+        {"slope": "2 * input", "intercept": 4, "variable0": "input"},
+        # expressions as arg values referencing other args is not currently supported
+        pytest.param(
+            {"slope": 2, "intercept": "2 * slope", "variable0": "input"},
+            marks=pytest.mark.xfail,
+        ),
+    ],
+)
+def test_single_function_variations(args, function, value, result):
+    m = create_model(
+        [
+            mdf.Node(
+                id="N",
+                input_ports=[mdf.InputPort(id="input")],
+                functions=[
+                    mdf.Function(id="f", args=args, function=function, value=value)
+                ],
+                output_ports=[mdf.OutputPort(id="output", value="f")],
+            )
+        ]
+    )
+
+    eg = EvaluableGraph(m.graphs[0])
+    eg.evaluate(initializer={"input": 1})
+
+    assert eg.enodes["N"].evaluable_outputs["output"].curr_value == result


### PR DESCRIPTION
Since #218, `Function.args` are not set when `Function.value` is set. I think reallowing use of `args` with `value` would provide several benefits

1. ability for projects using MDF to use identical value expressions without pre-substituting arguments. ex with a linear function as expression:

current requirement:
```json
"node1_linear_func": {
    "value": "2 * node1_input_port + 5"
}

"node2_linear_func": {
    "value": "3 * node2_input_port + 5"
}
```
allowed with args reenabled:
```json
"node1_linear_func": {
    "value": "slope * variable0 + intercept",
    "args": {
        "variable0": "node1_input_port",
        "slope": 2,
        "intercept": 5
    }
}

"node2_linear_func": {
    "value": "slope * variable0 + intercept",
    "args": {
        "variable0": "node2_input_port",
        "slope": 3,
        "intercept": 5
    }
}
```

2. continued support for more complex python expressions in `value`, including subscripting, which cannot be handled by sympy simplify. (This is used to replicate psyneulink behavior in several common situations)
3. less need for #247, without which any project that wants to use MDF would be required to perform function dependency resolution on its own and ensure functions are output into MDF in the proper order. 
