### PR TITLE
Replace sympy with ast

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     numpy
     matplotlib
     graphviz
-    sympy<=1.8
     onnx
     onnxruntime
     skl2onnx

--- a/src/modeci_mdf/interfaces/pytorch/exporter.py
+++ b/src/modeci_mdf/interfaces/pytorch/exporter.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 from inspect import getmembers, signature, getsource, isclass
 import modeci_mdf
 import numpy as np
-import sympy
 import torch
 from typing import Union, Dict, Any, Tuple, List, Callable
 import torch.nn as nn

--- a/src/modeci_mdf/mdf.py
+++ b/src/modeci_mdf/mdf.py
@@ -6,7 +6,6 @@ r"""
     environments using the :mod:`~modeci_mdf.interfaces` module.
 """
 import copy
-import sympy
 import numpy as np
 
 from typing import List, Tuple, Dict, Set, Any, Union, Optional
@@ -214,15 +213,7 @@ class Parameter(MdfBase):
         if self.default_initial_value is not None:
             return True
         if self.value is not None and type(self.value) == str:
-            # If we are dealing with a list of symbols, each must treated separately
-            arg_expr_list = get_required_variables_from_expression(self.value)
-
-            req_vars = []
-
-            for e in arg_expr_list:
-                param_expr = sympy.simplify(e)
-                req_vars.extend([str(s) for s in param_expr.free_symbols])
-            sf = self.id in req_vars
+            sf = self.id in get_required_variables_from_expression(self.value)
             """
             print(
                 "Checking whether %s is stateful, %s: %s"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,6 +9,7 @@ from modeci_mdf.execution_engine import get_required_variables_from_expression
         ((), []),
         ("", []),
         ("x", ["x"]),
+        ("x.y", ["x"]),
         ("3*x + y", ["x", "y"]),
         ("x[y]", ["x", "y"]),
         ("x[y[z]]", ["x", "y", "z"]),


### PR DESCRIPTION
sympy crashes for some expressions that we support (like those containing function calls, `math.sum` for example)