### PR TITLE
Replaced `bin` to `script` in Step 5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ The installation requires Python >= 3.7. See installation instructions at https:
     ```
 * Step 5 : Activate the virtual environment
     ```
-    source mdf-env/bin/activate
+    source mdf-env/script/activate
     ```
 * Step 6 : Install MDF
     ```


### PR DESCRIPTION
The code to activate the virtual environment: `source mdf-env/bin/activate` returns an error because the bin directory does not exist in the virtual environment. Hence, I replaced it with `source mdf-env/script/activate`  and it works fine.