### PR TITLE
execution_engine: handle numpy.number type in condition args

### DIFF
--- a/src/modeci_mdf/execution_engine.py
+++ b/src/modeci_mdf/execution_engine.py
@@ -1289,12 +1289,12 @@ class EvaluableGraph:
         # if specified as dict
         try:
             args = condition["kwargs"]
-        except (TypeError, KeyError):
+        except (IndexError, TypeError, KeyError):
             args = {}
 
         try:
             condition = Condition(condition["type"], **args)
-        except (TypeError, KeyError):
+        except (IndexError, TypeError, KeyError):
             pass
 
         cond_type = condition.type


### PR DESCRIPTION
numpy.number throws IndexError when attempting to subscript, unlike native python number types that throw TypeError