### PR TITLE
Docs/newer sphinx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,14 @@ jobs:
         dot -V
         python -m pytest -v -m "tensorflow" tests/
 
+    - name: Build Documentation
+      run: |
+        cd docs
+        python generate.py
+        cd sphinx
+        make clean
+        make html
+
     - name: Final version info for optional installed packages
       run: |
           pip list

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -145,14 +145,14 @@ intersphinx_mapping = {
     "pytest": ("https://docs.pytest.org/en/stable", None),
 }
 
-from sphinx.ext.autodoc import ClassLevelDocumenter, InstanceAttributeDocumenter
+from sphinx.ext.autodoc import ClassLevelDocumenter, AttributeDocumenter
 
 
 def add_directive_header(self, sig):
     ClassLevelDocumenter.add_directive_header(self, sig)
 
 
-InstanceAttributeDocumenter.add_directive_header = add_directive_header
+AttributeDocumenter.add_directive_header = add_directive_header
 
 
 import os

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ test =
     typing_extensions;python_version<'3.8'
 
 optional =
-    Sphinx~=3.0
+    Sphinx
     recommonmark>=0.5.0
     nbsphinx
     sphinx_copybutton


### PR DESCRIPTION
Hi @pgleeson 

I created this branch from the development branch and I have made two changes. They are:
1. I unpinned the sphinx version
2. I changed the deprecated "InstanceAttributeDocumenter" class to its alternative "AttributeDocumenter" in the conf.py file in docs. 

I used sphinx 6.2.1 to build the documentation. Although the documentation was generated, there were a lot of warnings and errors generated.