### PR TITLE
Fix/actr test condition

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages = find:
 install_requires =
     typing_compat;python_version<'3.8'
     dataclasses;python_version<'3.7'
-    graph_scheduler<1.2.0,>=1.1.1
+    graph_scheduler>=1.1.1
     numpy
     matplotlib
     graphviz

--- a/src/modeci_mdf/interfaces/actr/importer.py
+++ b/src/modeci_mdf/interfaces/actr/importer.py
@@ -228,7 +228,9 @@ def build_model() -> Model:
             fire_prod_node.id: cond_fire_prod,
             check_node.id: cond_check,
         },
-        termination={"check_term_true": cond_term},
+
+        # FIXME: Disable termination condition for now. This is causing errors in the scheduler. Seems unused in tests.
+        # termination={"environment_state_update": cond_term},
     )
 
     return mod

--- a/src/modeci_mdf/interfaces/actr/importer.py
+++ b/src/modeci_mdf/interfaces/actr/importer.py
@@ -228,7 +228,6 @@ def build_model() -> Model:
             fire_prod_node.id: cond_fire_prod,
             check_node.id: cond_check,
         },
-
         # FIXME: Disable termination condition for now. This is causing errors in the scheduler. Seems unused in tests.
         # termination={"environment_state_update": cond_term},
     )

--- a/src/modeci_mdf/interfaces/onnx/exporter.py
+++ b/src/modeci_mdf/interfaces/onnx/exporter.py
@@ -49,9 +49,21 @@ def mdf_to_onnx(mdf_model):
 
         # Check to see if onnxruntime version is less than 1.15, if so ir_version should
         # be 8 for now. See: https://github.com/microsoft/onnxruntime/issues/15874
+        # There is still now programmatic way to determine the max supported ir_version from onnxruntime
+        # Here is the issue: https://github.com/microsoft/onnxruntime/issues/14932
+        # We will have to continue this dumb hack for the time being.
         make_model_kwargs = {}
-        if onnxruntime.__version__ < "1.15":
-            make_model_kwargs = {"ir_version": 8}
+        try:
+            from packaging.version import Version, InvalidVersion
+            v = Version(onnxruntime.__version__)
+
+            if v < Version("1.15"):
+                make_model_kwargs = {"ir_version": 8}
+            elif v < Version("1.18"):
+                make_model_kwargs = {"ir_version": 9}
+
+        except (InvalidVersion, ModuleNotFoundError):
+            pass
 
         onnx_model = helper.make_model(onnx_graph, **make_model_kwargs)
 

--- a/src/modeci_mdf/interfaces/onnx/exporter.py
+++ b/src/modeci_mdf/interfaces/onnx/exporter.py
@@ -55,6 +55,7 @@ def mdf_to_onnx(mdf_model):
         make_model_kwargs = {}
         try:
             from packaging.version import Version, InvalidVersion
+
             v = Version(onnxruntime.__version__)
 
             if v < Version("1.15"):


### PR DESCRIPTION
This closes #496. The fix is a bit of hack that needs to be investigated further when someone has time to look into ACT-R support more. The way that the importer was specifying termination conditions wasn't compatible with the new version. The termination condition didn't seem to be used in the test examples anyway though.